### PR TITLE
Dedup endpoint ips from pool before add.

### DIFF
--- a/lib/Cassandra/Pool.pm
+++ b/lib/Cassandra/Pool.pm
@@ -86,7 +86,8 @@ sub add_pool_from_ring {
 	my $keyspace = shift || $self->{rcp_opts}->{keyspace};
 	if ($keyspace) {
 		my @nodes     = @{ $self->{pool}->get()->describe_ring($keyspace) };
-		my @nodes_ips = map {
+		my %aux; 
+		my @nodes_ips = grep  { $aux{$_}++ ? undef : $_ } map {
 			map { split( /\//, $_ ) }
 			  @{ $_->{rpc_endpoints} }
 		} @nodes;


### PR DESCRIPTION
I was getting 3 endpoits per  node from describe_ring function. So a failing node will be added 3 times.
